### PR TITLE
Issue#186 : updated take(until:) description and added unit test.

### DIFF
--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -769,12 +769,13 @@ public extension SignalProtocol {
     }
   }
 
-  /// Emit elements of the reciver until given signal completes and then complete the receiver.
+  /// Emit elements of the receiver until the given signal sends an event (of any kind)
+  /// and then completes the receiver (subsequent events on the receiver are ignored).
   public func take<S: SignalProtocol>(until signal: S) -> Signal<Element, Error> {
     return Signal { observer in
       let disposable = CompositeDisposable()
-
-      disposable += signal.observe { event in
+      
+      disposable += signal.observe { _ in
         observer.completed()
       }
 


### PR DESCRIPTION
# Reference
#186

# Description
Prior to this change `take(until:)` was described as terminating the receiver only for a completed event on the given signal. This has been updated to accurately state that it is for _any_ event that was sent on the provided signal.

Added Unit Test `testTakeUntil()` and verified that all tests pass with this change.

**Successful Test**
![success](https://user-images.githubusercontent.com/3268395/38115263-fc51dda0-3370-11e8-8054-ea74b701da37.png)

This shows that after elements 1 and 2 were sent on the receiver, the passed signal has sent an event and nothing else is emitted on the receiver.

**Failing Test** : this shows that all events (1, 2 and 3) were observed on the receiver because no event was passed on the provided signal. Additional tests should show all other possible cases.
![failing test](https://user-images.githubusercontent.com/3268395/38115199-d14c40fa-3370-11e8-9327-6103e815aedd.png)

**Test Results**
![test results](https://user-images.githubusercontent.com/3268395/38115396-7f8f742a-3371-11e8-9931-8dc7850ff1f2.png)

## Note

The description was updated instead of the behavior modified as per Srdan's instructions in his comment of[ PR#187](https://github.com/DeclarativeHub/ReactiveKit/pull/187).