### PR TITLE
Fix missing colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,7 +1192,7 @@ fetchImage
         case .loaded(let image):
             // hide loading indicator
             // display image
-        case .failed(let error)
+        case .failed(let error):
             // hide loading indicator
             // display error message
         }


### PR DESCRIPTION
Just noticed there was a missing colon in the README while implementing loadingState.