### PR TITLE
Tell Travis CI to use Xcode 9.3/Swift 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode9.3
 
 # Travis is currently experiencing issues with Xcode builds: https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-257964767
 # When this is resolved, remove the entire `before_install` block, as well as the `travis_retry` command below.
 before_install:
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 7 (11.0" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 7 (11.3" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
   - echo $IOS_SIMULATOR_UDID
   - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
 
@@ -12,7 +12,7 @@ install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail && travis_retry xcodebuild -project ReactiveKit.xcodeproj -scheme ReactiveKit-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' test | xcpretty
+  - set -o pipefail && travis_retry xcodebuild -project ReactiveKit.xcodeproj -scheme ReactiveKit-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.3' test | xcpretty
   - swift test
 
 after_success:


### PR DESCRIPTION
Looks like Travis CI is failing, as it is expecting Swift 4.1, but can only access Swift 4.0. This PR will get the build back in the green.