### PR TITLE
Fixing deprecation warning for README code

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ let signal = SafeSignal.timer(element: 5, time: 60)
 Finally, when you need a signal that sends an integer every `interval` seconds, do
 
 ```swift
-let signal = SafeSignal.interval(5)
+let signal = SafeSignal(sequence: 0..., interval: 5)
 ```
 ```
 ---0---1---2---3---...>


### PR DESCRIPTION
When running code in the README there is a warning that is produced:

> 'interval(_:queue:)' is deprecated: Please use Signal(sequence: 0..., interval: N) instead

This PR fixes that warning by using the new method in the README example code.