### PR TITLE
Fixed race conditions in dispose bag and subjects with unit testing

### DIFF
--- a/ReactiveKit.xcodeproj/project.pbxproj
+++ b/ReactiveKit.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		16C33B841BEFBAC900A0DBE0 /* ReactiveKit.h in Headers */ = {isa = PBXBuildFile; fileRef = ECBCCDD31BEB6B9A00723476 /* ReactiveKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16C33B851BEFBAC900A0DBE0 /* ReactiveKit.h in Headers */ = {isa = PBXBuildFile; fileRef = ECBCCDD31BEB6B9A00723476 /* ReactiveKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16D30EBD1D6595AB00C2435D /* ReactiveKit.h in Headers */ = {isa = PBXBuildFile; fileRef = ECBCCDD31BEB6B9A00723476 /* ReactiveKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		19276399228F779200EDF2C0 /* SubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19276398228F779200EDF2C0 /* SubjectTests.swift */; };
 		EC48D30D224FB5C400284EA0 /* SignalProtocol+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC48D2F1224FB5C400284EA0 /* SignalProtocol+Utilities.swift */; };
 		EC48D30E224FB5C400284EA0 /* SignalProtocol+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC48D2F1224FB5C400284EA0 /* SignalProtocol+Utilities.swift */; };
 		EC48D30F224FB5C400284EA0 /* SignalProtocol+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC48D2F1224FB5C400284EA0 /* SignalProtocol+Utilities.swift */; };
@@ -146,6 +147,7 @@
 		16C33AF91BEFB72500A0DBE0 /* ReactiveKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		16C33B161BEFB9CB00A0DBE0 /* ReactiveKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		16C33B241BEFBA0100A0DBE0 /* ReactiveKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		19276398228F779200EDF2C0 /* SubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectTests.swift; sourceTree = "<group>"; };
 		EC48D2F1224FB5C400284EA0 /* SignalProtocol+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SignalProtocol+Utilities.swift"; sourceTree = "<group>"; };
 		EC48D2F2224FB5C400284EA0 /* Observer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
 		EC48D2F3224FB5C400284EA0 /* SignalProtocol+Monad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SignalProtocol+Monad.swift"; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				EC48D381224FB66100284EA0 /* Helpers.swift */,
 				EC48D382224FB66100284EA0 /* SignalTests.swift */,
 				EC48D380224FB66100284EA0 /* PropertyTests.swift */,
+				19276398228F779200EDF2C0 /* SubjectTests.swift */,
 			);
 			path = ReactiveKitTests;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				19276399228F779200EDF2C0 /* SubjectTests.swift in Sources */,
 				EC48D384224FB66100284EA0 /* PropertyTests.swift in Sources */,
 				EC48D386224FB66100284EA0 /* SignalTests.swift in Sources */,
 				EC48D385224FB66100284EA0 /* Helpers.swift in Sources */,

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -34,7 +34,7 @@ public protocol PropertyProtocol {
 public final class Property<Value>: PropertyProtocol, SubjectProtocol, BindableProtocol, DisposeBagProvider {
     
     private var _value: Value
-    private let subject = PublishSubject<Value, Never>()
+    private let subject: Subject<Value, Never>
     private let lock = NSRecursiveLock(name: "reactive_kit.property")
 
     public var bag: DisposeBag {
@@ -54,8 +54,9 @@ public final class Property<Value>: PropertyProtocol, SubjectProtocol, BindableP
         }
     }
     
-    public init(_ value: Value) {
+    public init(_ value: Value, subject: Subject<Value, Never> = PublishSubject()) {
         _value = value
+        self.subject = subject
     }
     
     public func on(_ event: Event<Value, Never>) {

--- a/Tests/ReactiveKitTests/SubjectTests.swift
+++ b/Tests/ReactiveKitTests/SubjectTests.swift
@@ -1,0 +1,282 @@
+//
+//  SubjectTests.swift
+//  ReactiveKit
+//
+//  Created by Théophane Rupin on 5/17/19.
+//  Copyright © 2019 DeclarativeHub. All rights reserved.
+//
+
+import XCTest
+import ReactiveKit
+
+final class SubjectTests: XCTestCase {
+    
+    // MARK: - Subject
+    
+    func testSubjectForThreadSafety() {
+        
+        let eventsCount = 10000
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = Subject<Int, Never>()
+            
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observe { _ in }.dispose(in: bag)
+            }
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(1)
+                bag.dispose()
+            }
+        }
+
+        let waitForRaceConditionExpectation = expectation(description: "race_condition?")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            waitForRaceConditionExpectation.fulfill()
+        }
+        wait(for: [waitForRaceConditionExpectation], timeout: 3)
+    }
+    
+    // MARK: - ReplaySubject
+    
+    func testReplaySubjectForThreadSafetySendLast() {
+        
+        let eventsCount = 10000
+        
+        let eventsExpectation = expectation(description: "events")
+        eventsExpectation.expectedFulfillmentCount = eventsCount
+        
+        let countDispatchQueue = DispatchQueue(label: "count")
+        var actualEventsCount = 0
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = ReplaySubject<Int, Never>()
+            
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observeNext { _ in
+                    countDispatchQueue.async {
+                        actualEventsCount += 1
+                    }
+                    eventsExpectation.fulfill()
+                }.dispose(in: bag)
+            }
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(1)
+                bag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 2) { _ in
+            countDispatchQueue.sync {
+                guard actualEventsCount != eventsCount else { return }
+                XCTFail("Short by \(eventsCount - actualEventsCount).")
+            }
+        }
+    }
+    
+    func testReplaySubjectForThreadSafetySendFirst() {
+        
+        let eventsCount = 10000
+        
+        let eventsExpectation = expectation(description: "events")
+        eventsExpectation.expectedFulfillmentCount = eventsCount
+        
+        let countDispatchQueue = DispatchQueue(label: "count")
+        var actualEventsCount = 0
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = ReplaySubject<Int, Never>()
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(1)
+                bag.dispose()
+            }
+            
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observeNext { _ in
+                    countDispatchQueue.async {
+                        actualEventsCount += 1
+                    }
+                    eventsExpectation.fulfill()
+                    }.dispose(in: bag)
+            }
+        }
+        
+        waitForExpectations(timeout: 2) { _ in
+            countDispatchQueue.sync {
+                guard actualEventsCount != eventsCount else { return }
+                XCTFail("Short by \(eventsCount - actualEventsCount).")
+            }
+        }
+    }
+    
+    // MARK: - ReplayOneSubject
+    
+    func testReplayOneSubjectForThreadSafetySendLast() {
+        
+        let eventsCount = 10000
+
+        let eventsExpectation = expectation(description: "events")
+        eventsExpectation.expectedFulfillmentCount = eventsCount
+
+        let countDispatchQueue = DispatchQueue(label: "count")
+        var actualEventsCount = 0
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = ReplayOneSubject<Int, Never>()
+
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observeNext { _ in
+                    countDispatchQueue.async {
+                        actualEventsCount += 1
+                    }
+                    eventsExpectation.fulfill()
+                }.dispose(in: bag)
+            }
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(1)
+                bag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 2) { _ in
+            countDispatchQueue.sync {
+                guard actualEventsCount != eventsCount else { return }
+                XCTFail("Short by \(eventsCount - actualEventsCount).")
+            }
+        }
+    }
+
+    func testReplayOneSubjectForThreadSafetySendFirst() {
+        
+        let eventsCount = 10000
+        
+        let eventsExpectation = expectation(description: "events")
+        eventsExpectation.expectedFulfillmentCount = eventsCount
+        
+        let countDispatchQueue = DispatchQueue(label: "count")
+        var actualEventsCount = 0
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = ReplayOneSubject<Int, Never>()
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(1)
+                bag.dispose()
+            }
+            
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observeNext { _ in
+                    countDispatchQueue.async {
+                        actualEventsCount += 1
+                    }
+                    eventsExpectation.fulfill()
+                }.dispose(in: bag)
+            }
+        }
+        
+        waitForExpectations(timeout: 2) { _ in
+            countDispatchQueue.sync {
+                guard actualEventsCount != eventsCount else { return }
+                XCTFail("Short by \(eventsCount - actualEventsCount).")
+            }
+        }
+    }
+    
+    // MARK: - ReplayLoadingValueSubject
+    
+    func testReplayLoadingValueSubjectForThreadSafetySendLast() {
+        
+        let eventsCount = 10000
+        
+        let eventsExpectation = expectation(description: "events")
+        eventsExpectation.expectedFulfillmentCount = eventsCount
+        
+        let countDispatchQueue = DispatchQueue(label: "count")
+        var actualEventsCount = 0
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = ReplayLoadingValueSubject<Int, Never, Never>()
+            
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observeNext { _ in
+                    countDispatchQueue.async {
+                        actualEventsCount += 1
+                    }
+                    eventsExpectation.fulfill()
+                }.dispose(in: bag)
+            }
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(.loaded(1))
+                bag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 2) { _ in
+            countDispatchQueue.sync {
+                guard actualEventsCount != eventsCount else { return }
+                XCTFail("Short by \(eventsCount - actualEventsCount).")
+            }
+        }
+    }
+    
+    func testReplayLoadingValueSubjectForThreadSafetySendFirst() {
+        
+        let eventsCount = 10000
+        
+        let eventsExpectation = expectation(description: "events")
+        eventsExpectation.expectedFulfillmentCount = eventsCount
+        
+        let countDispatchQueue = DispatchQueue(label: "count")
+        var actualEventsCount = 0
+        
+        for _ in 0..<eventsCount {
+            let bag = DisposeBag()
+            let subject = ReplayLoadingValueSubject<Int, Never, Never>()
+            
+            let dispatchQueueTwo = DispatchQueue(label: "two")
+            dispatchQueueTwo.async {
+                subject.next(.loaded(1))
+                bag.dispose()
+            }
+            
+            let dispatchQueueOne = DispatchQueue(label: "one")
+            dispatchQueueOne.async {
+                subject.observeNext { _ in
+                    countDispatchQueue.async {
+                        actualEventsCount += 1
+                    }
+                    eventsExpectation.fulfill()
+                }.dispose(in: bag)
+            }
+        }
+        
+        waitForExpectations(timeout: 2) { _ in
+            countDispatchQueue.sync {
+                guard actualEventsCount != eventsCount else { return }
+                XCTFail("Short by \(eventsCount - actualEventsCount).")
+            }
+        }
+    }
+}


### PR DESCRIPTION
We at Scribd are testing out a new system using ReactiveKit as the data delivery.

Our tests were failing intermittently, and after a lot of debugging we realized that there was a race condition in the subject class. This involves both data losses (observers of `ReplayOneSubjects` never 
receiving the first event) and crashes.

We solved it locally and then rewrote our solution in your classes and added unit tests. We hope you find this a valuable addition to the framework.