### PR TITLE
Threadsafety improvements

### DIFF
--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -59,35 +59,45 @@ public struct NonDisposable: Disposable {
 
 /// A disposable that just encapsulates disposed state.
 public final class SimpleDisposable: Disposable {
-    public private(set) var isDisposed: Bool = false
+    
+    private let dispatchQueue = DispatchQueue(label: "com.reactive_kit.simple_disposable")
+
+    private var _isDisposed = false
+    public var isDisposed: Bool {
+        return dispatchQueue.sync { _isDisposed }
+    }
     
     public func dispose() {
-        isDisposed = true
+        dispatchQueue.async(flags: .barrier) {
+            self._isDisposed = true
+        }
     }
     
     public init(isDisposed: Bool = false) {
-        self.isDisposed = isDisposed
+        _isDisposed = isDisposed
     }
 }
 
 /// A disposable that executes the given block upon disposing.
 public final class BlockDisposable: Disposable {
     
+    private let dispatchQueue = DispatchQueue(label: "com.reactive_kit.block_disposable")
+    
     public var isDisposed: Bool {
-        return handler == nil
+        return dispatchQueue.sync { _handler == nil }
     }
     
-    private var handler: (() -> ())?
-    private let lock = NSRecursiveLock(name: "com.reactivekit.blockdisposable")
+    private var _handler: (() -> ())?
     
     public init(_ handler: @escaping () -> ()) {
-        self.handler = handler
+        _handler = handler
     }
     
     public func dispose() {
-        lock.lock(); defer { lock.unlock() }
-        if let handler = handler {
-            self.handler = nil
+        if let handler = dispatchQueue.sync(execute: { _handler }) {
+            dispatchQueue.async(flags: .barrier) {
+                self._handler = nil
+            }
             handler()
         }
     }
@@ -96,14 +106,26 @@ public final class BlockDisposable: Disposable {
 /// A disposable that disposes itself upon deallocation.
 public final class DeinitDisposable: Disposable {
     
-    public var otherDisposable: Disposable? = nil
+    private let dispatchQueue = DispatchQueue(label: "com.reactive_kit.deinit_disposable")
+    
+    private var _otherDisposable: Disposable?
+    public var otherDisposable: Disposable? {
+        set {
+            dispatchQueue.async(flags: .barrier) {
+                self._otherDisposable = newValue
+            }
+        }
+        get {
+            return dispatchQueue.sync { _otherDisposable }
+        }
+    }
     
     public var isDisposed: Bool {
         return otherDisposable == nil
     }
     
     public init(disposable: Disposable) {
-        otherDisposable = disposable
+        _otherDisposable = disposable
     }
     
     public func dispose() {
@@ -118,9 +140,15 @@ public final class DeinitDisposable: Disposable {
 /// A disposable that disposes a collection of disposables upon its own disposing.
 public final class CompositeDisposable: Disposable {
     
-    public private(set) var isDisposed: Bool = false
+    private let lock = NSRecursiveLock(name: "com.reactive_kit.composite_disposable")
+    
+    private var _isDisposed = false
+    public var isDisposed: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isDisposed
+    }
+    
     private var disposables: [Disposable] = []
-    private let lock = NSRecursiveLock(name: "com.reactivekit.compositedisposable")
     
     public convenience init() {
         self.init([])
@@ -132,7 +160,7 @@ public final class CompositeDisposable: Disposable {
     
     public func add(disposable: Disposable) {
         lock.lock(); defer { lock.unlock() }
-        if isDisposed {
+        if _isDisposed {
             disposable.dispose()
         } else {
             disposables.append(disposable)
@@ -146,7 +174,7 @@ public final class CompositeDisposable: Disposable {
     
     public func dispose() {
         lock.lock(); defer { lock.unlock() }
-        isDisposed = true
+        _isDisposed = true
         disposables.forEach { $0.dispose() }
         disposables.removeAll()
     }
@@ -154,15 +182,20 @@ public final class CompositeDisposable: Disposable {
 
 /// A disposable that disposes other disposable upon its own disposing.
 public final class SerialDisposable: Disposable {
-    
-    public private(set) var isDisposed: Bool = false
-    private let lock = NSRecursiveLock(name: "com.reactivekit.serialdisposable")
+
+    private let lock = NSRecursiveLock(name: "com.reactive_kit.serial_disposable")
+
+    private var _isDisposed = false
+    public var isDisposed: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isDisposed
+    }
     
     /// Will dispose other disposable immediately if self is already disposed.
     public var otherDisposable: Disposable? {
         didSet {
             lock.lock(); defer { lock.unlock() }
-            if isDisposed {
+            if _isDisposed {
                 otherDisposable?.dispose()
             }
         }
@@ -174,8 +207,8 @@ public final class SerialDisposable: Disposable {
     
     public func dispose() {
         lock.lock(); defer { lock.unlock() }
-        if !isDisposed {
-            isDisposed = true
+        if !_isDisposed {
+            _isDisposed = true
             otherDisposable?.dispose()
         }
     }
@@ -206,16 +239,22 @@ public protocol DisposeBagProtocol: Disposable {
 ///
 /// When bag gets deallocated, it will dispose all disposables it contains.
 public final class DisposeBag: DisposeBagProtocol {
-    
-    private var disposables: [Disposable] = []
-    private var subject: ReplayOneSubject<Void, Never>?
 
-    private let subjectLoadingLock = NSRecursiveLock(name: "com.reactivekit.disposebag.subject")
-    private let disposablesLock = NSRecursiveLock(name: "com.reactivekit.disposebag.disposables")
+    private let disposablesLock = NSRecursiveLock(name: "com.reactive_kit.dispose_bag.disposables")
+    private let subjectLock = NSRecursiveLock(name: "com.reactive_kit.dispose_bag.subject")
+
+    private var _disposables: [Disposable] = []
+
+    private var _subject: ReplayOneSubject<Void, Never>?
+    private var subject: ReplayOneSubject<Void, Never>? {
+        subjectLock.lock(); defer { subjectLock.unlock() }
+        return _subject
+    }
 
     /// `true` if bag is empty, `false` otherwise.
     public var isDisposed: Bool {
-        return disposables.count == 0
+        disposablesLock.lock(); defer { disposablesLock.unlock() }
+        return _disposables.count == 0
     }
     
     public init() {
@@ -225,14 +264,14 @@ public final class DisposeBag: DisposeBagProtocol {
     /// Disposable will be disposed when the bag is deallocated.
     public func add(disposable: Disposable) {
         disposablesLock.lock(); defer { disposablesLock.unlock() }
-        disposables.append(disposable)
+        _disposables.append(disposable)
     }
     
     /// Add the given disposables to the bag.
     /// Disposables will be disposed when the bag is deallocated.
     public func add(disposables: [Disposable]) {
         disposablesLock.lock(); defer { disposablesLock.unlock() }
-        disposables.forEach(add)
+        _disposables.forEach(add)
     }
     
     /// Add a disposable to a dispose bag.
@@ -248,18 +287,15 @@ public final class DisposeBag: DisposeBagProtocol {
     /// Disposes all disposables that are currenty in the bag.
     public func dispose() {
         disposablesLock.lock(); defer { disposablesLock.unlock() }
-        disposables.forEach { $0.dispose() }
-        disposables.removeAll()
+        _disposables.forEach { $0.dispose() }
+        _disposables.removeAll()
     }
     
     /// A signal that fires `completed` event when the bag gets deallocated.
     public var deallocated: SafeSignal<Void> {
-        subjectLoadingLock.lock()
-        if subject == nil {
-            subject = ReplayOneSubject()
-        }
-        subjectLoadingLock.unlock()
-        return subject!.toSignal()
+        subjectLock.lock(); defer { subjectLock.unlock() }
+        let subject = _subject ?? ReplaySubject()
+        return subject.toSignal()
     }
     
     deinit {

--- a/Sources/Signal.swift
+++ b/Sources/Signal.swift
@@ -97,7 +97,7 @@ extension Signal {
     /// - Parameter element: An element to emit in the `next` event.
     /// - Parameter interval: A number of seconds to delay the emission.
     /// - Parameter queue: A queue used to delay the emission. Defaults to a new serial queue.
-    public init(just element: Element, after interval: Double, queue: DispatchQueue = DispatchQueue(label: "reactive_kit.just_after")) {
+    public init(just element: Element, after interval: Double, queue: DispatchQueue = DispatchQueue(label: "com.reactive_kit.signal.just_after")) {
         self = Signal(just: element).delay(interval: interval, on: queue)
     }
 
@@ -161,11 +161,11 @@ extension Signal {
     /// - Parameter sequence: A sequence of elements to convert into a series of `next` events.
     /// - Parameter interval: A number of seconds to wait between each emission.
     /// - Parameter queue: A queue used to delay the emissions. Defaults to a new serial queue.
-    public init<S: Sequence>(sequence: S, interval: Double, queue: DispatchQueue = DispatchQueue(label: "reactive_kit.sequence_interval"))
+    public init<S: Sequence>(sequence: S, interval: Double, queue: DispatchQueue = DispatchQueue(label: "com.reactive_kit.signal.sequence"))
         where S.Iterator.Element == Element {
         self.init { observer in
             var iterator = sequence.makeIterator()
-            var dispatch: (() -> Void)!
+            var dispatch: (() -> Void)?
             let disposable = SimpleDisposable()
             dispatch = {
                 queue.after(when: interval) {
@@ -179,10 +179,10 @@ extension Signal {
                         return
                     }
                     observer.receive(element)
-                    dispatch()
+                    dispatch?()
                 }
             }
-            dispatch()
+            dispatch?()
             return disposable
         }
     }

--- a/Sources/SignalProtocol+ErrorHandling.swift
+++ b/Sources/SignalProtocol+ErrorHandling.swift
@@ -99,33 +99,38 @@ extension SignalProtocol {
     public func retry(times: Int) -> Signal<Element, Error> {
         guard times > 0 else { return toSignal() }
         return Signal { observer in
-            var remainingAttempts = times
+            let lock = NSRecursiveLock(name: "com.reactive_kit.signal.retry")
+            var _remainingAttempts = times
             let serialDisposable = SerialDisposable(otherDisposable: nil)
-            var attempt: (() -> Void)?
-            attempt = {
+            var _attempt: (() -> Void)?
+            _attempt = {
                 serialDisposable.otherDisposable?.dispose()
                 serialDisposable.otherDisposable = self.observe { event in
                     switch event {
                     case .next(let element):
                         observer.receive(element)
                     case .failed(let error):
-                        if remainingAttempts > 0 {
-                            remainingAttempts -= 1
-                            attempt?()
+                        lock.lock(); defer { lock.unlock() }
+                        if _remainingAttempts > 0 {
+                            _remainingAttempts -= 1
+                            _attempt?()
                         } else {
-                            attempt = nil
+                            _attempt = nil
                             observer.receive(completion: .failure(error))
                         }
                     case .completed:
-                        attempt = nil
+                        lock.lock(); defer { lock.unlock() }
+                        _attempt = nil
                         observer.receive(completion: .finished)
                     }
                 }
             }
-            attempt?()
+            lock.lock(); defer { lock.unlock() }
+            _attempt?()
             return BlockDisposable {
                 serialDisposable.dispose()
-                attempt = nil
+                lock.lock(); defer { lock.unlock() }
+                _attempt = nil
             }
         }
     }
@@ -135,9 +140,10 @@ extension SignalProtocol {
     /// - parameter shouldRetry: Retries only if this returns true for a given error. Defaults to always returning true.
     public func retry<S: SignalProtocol>(when other: S, if shouldRetry: @escaping (Error) -> Bool = { _ in true }) -> Signal<Element, Error> where S.Error == Never {
         return Signal { observer in
+            let lock = NSRecursiveLock(name: "com.reactive_kit.signal.retry")
             let serialDisposable = SerialDisposable(otherDisposable: nil)
-            var attempt: (() -> Void)?
-            attempt = {
+            var _attempt: (() -> Void)?
+            _attempt = {
                 serialDisposable.otherDisposable?.dispose()
                 let compositeDisposable = CompositeDisposable()
                 serialDisposable.otherDisposable = compositeDisposable
@@ -146,16 +152,18 @@ extension SignalProtocol {
                     case .next(let element):
                         observer.receive(element)
                     case .completed:
-                        attempt = nil
+                        lock.lock(); defer { lock.unlock() }
+                        _attempt = nil
                         observer.receive(completion: .finished)
                     case .failed(let error):
                         if shouldRetry(error) {
                             compositeDisposable += other.observe { otherEvent in
+                                lock.lock(); defer { lock.unlock() }
                                 switch otherEvent {
                                 case .next:
-                                    attempt?()
+                                    _attempt?()
                                 case .completed:
-                                    attempt = nil
+                                    _attempt = nil
                                     observer.receive(completion: .failure(error))
                                 }
                             }
@@ -165,29 +173,33 @@ extension SignalProtocol {
                     }
                 }
             }
-            attempt?()
+            lock.lock(); defer { lock.unlock() }
+            _attempt?()
             return serialDisposable
         }
     }
 
     /// Error out if the `interval` time passes with no emitted elements.
-    public func timeout(after interval: Double, with error: Error, on queue: DispatchQueue = DispatchQueue(label: "reactive_kit.timeout")) -> Signal<Element, Error> {
+    public func timeout(after interval: Double, with error: Error, on queue: DispatchQueue = DispatchQueue(label: "com.reactive_kit.signal.timeout")) -> Signal<Element, Error> {
         return Signal { observer in
-            var completed = false
+            let lock = NSRecursiveLock(name: "com.reactive_kit.signal.timeout")
+            var _completed = false
             let timeoutWhenPossible: () -> Disposable = {
                 return queue.disposableAfter(when: interval) {
-                    if !completed {
-                        completed = true
+                    lock.lock(); defer { lock.unlock() }
+                    if !_completed {
+                        _completed = true
                         observer.receive(completion: .failure(error))
                     }
                 }
             }
-            var lastSubscription = timeoutWhenPossible()
+            var _lastSubscription = timeoutWhenPossible()
             return self.observe { event in
-                lastSubscription.dispose()
+                lock.lock(); defer { lock.unlock() }
+                _lastSubscription.dispose()
                 observer.on(event)
-                completed = event.isTerminal
-                lastSubscription = timeoutWhenPossible()
+                _completed = event.isTerminal
+                _lastSubscription = timeoutWhenPossible()
             }
         }
     }

--- a/Tests/ReactiveKitTests/SubjectTests.swift
+++ b/Tests/ReactiveKitTests/SubjectTests.swift
@@ -13,34 +13,101 @@ final class SubjectTests: XCTestCase {
     
     // MARK: - Subject
     
-    func testSubjectForThreadSafety() {
+    func testSubjectForThreadSafety_oneEventDispatchedOnALotOfSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 10000
         
-        let eventsCount = 10000
-        
-        for _ in 0..<eventsCount {
-            let bag = DisposeBag()
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
             let subject = Subject<Int, Never>()
-            
-            let dispatchQueueOne = DispatchQueue(label: "one")
-            dispatchQueueOne.async {
-                subject.observe { _ in }.dispose(in: bag)
-            }
-            
-            let dispatchQueueTwo = DispatchQueue(label: "two")
-            dispatchQueueTwo.async {
-                subject.send(1)
-                bag.dispose()
+            subject.stress(with: [subject], eventsCount: 1, expectation: exp).dispose(in: disposeBag)
+            DispatchQueue.main.async {
+                disposeBag.dispose()
             }
         }
 
-        let waitForRaceConditionExpectation = expectation(description: "race_condition?")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            waitForRaceConditionExpectation.fulfill()
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testSubjectForThreadSafety_lotsOfEventsDispatchedOnOneSubject() {
+        let exp = expectation(description: "race_condition?")
+
+        let disposeBag = DisposeBag()
+        let subject = Subject<Int, Never>()
+       
+        subject.stress(with: [subject],
+                       queuesCount: 10,
+                       eventsCount: 3000,
+                       expectation: exp)
+            .dispose(in: disposeBag)
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testSubjectForThreadSafety_someEventsDispatchedOnSomeSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 100
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = Subject<Int, Never>()
+            subject.stress(with: [subject], expectation: exp).dispose(in: disposeBag)
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
         }
-        wait(for: [waitForRaceConditionExpectation], timeout: 3)
+        
+        waitForExpectations(timeout: 3)
     }
     
     // MARK: - ReplaySubject
+    
+    func testReplaySubjectForThreadSafety_oneEventDispatchedOnALotOfSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 10000
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = ReplaySubject<Int, Never>()
+            subject.stress(with: [subject], eventsCount: 1, expectation: exp).dispose(in: disposeBag)
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testReplaySubjectForThreadSafety_lotsOfEventsDispatchedOnOneSubject() {
+        let exp = expectation(description: "race_condition?")
+        
+        let disposeBag = DisposeBag()
+        let subject = ReplaySubject<Int, Never>()
+        
+        subject.stress(with: [subject],
+                       queuesCount: 10,
+                       eventsCount: 3000,
+                       expectation: exp)
+            .dispose(in: disposeBag)
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testReplaySubjectForThreadSafety_someEventsDispatchedOnSomeSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 100
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = ReplaySubject<Int, Never>()
+            subject.stress(with: [subject], expectation: exp).dispose(in: disposeBag)
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 3)
+    }
     
     func testReplaySubjectForThreadSafetySendLast() {
         
@@ -108,7 +175,7 @@ final class SubjectTests: XCTestCase {
                         actualEventsCount += 1
                     }
                     eventsExpectation.fulfill()
-                    }.dispose(in: bag)
+                }.dispose(in: bag)
             }
         }
         
@@ -121,6 +188,53 @@ final class SubjectTests: XCTestCase {
     }
     
     // MARK: - ReplayOneSubject
+    
+    func testReplayOneSubjectForThreadSafety_oneEventDispatchedOnALotOfSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 10000
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = ReplayOneSubject<Int, Never>()
+            subject.stress(with: [subject], eventsCount: 1, expectation: exp).dispose(in: disposeBag)
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testReplayOneSubjectForThreadSafety_lotsOfEventsDispatchedOnOneSubject() {
+        let exp = expectation(description: "race_condition?")
+        
+        let disposeBag = DisposeBag()
+        let subject = ReplayOneSubject<Int, Never>()
+        
+        subject.stress(with: [subject],
+                       queuesCount: 10,
+                       eventsCount: 3000,
+                       expectation: exp)
+            .dispose(in: disposeBag)
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testReplayOneSubjectForThreadSafety_someEventsDispatchedOnSomeSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 100
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = ReplayOneSubject<Int, Never>()
+            subject.stress(with: [subject], expectation: exp).dispose(in: disposeBag)
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 3)
+    }
     
     func testReplayOneSubjectForThreadSafetySendLast() {
         
@@ -201,6 +315,62 @@ final class SubjectTests: XCTestCase {
     }
     
     // MARK: - ReplayLoadingValueSubject
+    
+    func testReplayLoadingValueSubjectForThreadSafety_oneEventDispatchedOnALotOfSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 10000
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = ReplayLoadingValueSubject<Int, Never, Never>()
+
+            subject.stress(with: [{ subject.send(.loaded($0)) }],
+                           eventsCount: 1,
+                           expectation: exp)
+                .dispose(in: disposeBag)
+
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testReplayLoadingValueSubjectForThreadSafety_lotsOfEventsDispatchedOnOneSubject() {
+        let exp = expectation(description: "race_condition?")
+        
+        let disposeBag = DisposeBag()
+        let subject = ReplayLoadingValueSubject<Int, Never, Never>()
+        
+        subject.stress(with: [{ subject.send(.loaded($0)) }],
+                       queuesCount: 10,
+                       eventsCount: 3000,
+                       expectation: exp)
+            .dispose(in: disposeBag)
+        
+        waitForExpectations(timeout: 3)
+    }
+    
+    func testReplayLoadingValueSubjectForThreadSafety_someEventsDispatchedOnSomeSubjects() {
+        let exp = expectation(description: "race_condition?")
+        exp.expectedFulfillmentCount = 100
+        
+        for _ in 0..<exp.expectedFulfillmentCount {
+            let disposeBag = DisposeBag()
+            let subject = ReplayLoadingValueSubject<Int, Never, Never>()
+
+            subject.stress(with: [{ subject.send(.loaded($0)) }],
+                           expectation: exp)
+                .dispose(in: disposeBag)
+
+            DispatchQueue.main.async {
+                disposeBag.dispose()
+            }
+        }
+        
+        waitForExpectations(timeout: 3)
+    }
     
     func testReplayLoadingValueSubjectForThreadSafetySendLast() {
         


### PR DESCRIPTION
Since we (@Scribd) have been using `ReactiveKit` in a heavily multi threaded environment for now several weeks, we encountered few race conditions, dead locks and timing issues. 

It pushed me to make a full pass over the project in order to fix as many threadsafety (sometimes potential) issues as possible. I also wrote some multithreaded stress tests which I hope will help to catch regressions.

While I was at it, I tried to follow a guideline for the multithreaded code.

Here are the few rules I followed:
- Locks and dispatch queues should always be private.
- All read write operations on mutable resources should be synchronized somehow.
- Non thread safe mutable/ing resources/methods should be prefixed with `_` and private.
- If the needed timing allows it, use a dispatch queue with an `async` block for writing operations and a `sync` block for reading operations. Otherwise, use a `NSRecursiveLock`. 

I hope this will find a useful place in `ReactiveKit`.