### PR TITLE
Fixed a runtime crash in Xcode 11.2

### DIFF
--- a/Sources/Subjects.swift
+++ b/Sources/Subjects.swift
@@ -104,6 +104,11 @@ open class Subject<Element, Error: Swift.Error>: SubjectProtocol {
     open func willAdd(observer: @escaping Observer<Element, Error>) {
     }
     
+    public var isTerminated: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isTerminated
+    }
+    
     private let lock = NSRecursiveLock(name: "com.reactive_kit.subject.lock")
     private let deletedObserversLock = NSRecursiveLock(name: "com.reactive_kit.subject.deleted_observers")
 
@@ -115,10 +120,6 @@ open class Subject<Element, Error: Swift.Error>: SubjectProtocol {
     private var _deletedObservers = Set<Token>()
     
     private var _isTerminated: Bool = false
-    public var isTerminated: Bool {
-        lock.lock(); defer { lock.unlock() }
-        return _isTerminated
-    }
     
     public let disposeBag = DisposeBag()
     


### PR DESCRIPTION
This hopefully fixes #233. 

For some reason the _order_ in which methods were defined in `Subject` was important. The previous code caused different runtime crashes (mostly `EXC_BAD_ACCESS`) when accessing those methods.
This seems to be a bug in the Swift runtime and/or the iOS 13.2 SDK. I added a comment about that.