### PR TITLE
Fixed deadlock in retry signal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: swift
-osx_image: xcode10.2
+osx_image: xcode11.2.1
 
 jobs:
     include:
         - stage: "Xcode"
           name: "Run tests on iOS"
-          script: xcrun xcodebuild test -destination "platform=iOS Simulator,OS=12.2,name=iPhone X" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-iOS"
+          script: xcrun xcodebuild test -destination "platform=iOS Simulator,OS=13.2,name=iPhone X" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-iOS"
           after_success: 'bash <(curl -s https://codecov.io/bash)'
         -
           name: "Build for macOS"
           script: xcrun xcodebuild build -destination "platform=macOS" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-macOS"
         -
           name: "Build for tvOS"
-          script: xcrun xcodebuild build -destination "platform=tvOS Simulator,OS=12.2,name=Apple TV 4K" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-tvOS"
+          script: xcrun xcodebuild build -destination "platform=tvOS Simulator,OS=13.2,name=Apple TV 4K" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-tvOS"
         -
           name: "Build for watchOS"
-          script: xcrun xcodebuild build -destination "platform=watchOS Simulator,OS=5.2,name=Apple Watch Series 4 - 44mm" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-watchOS"
+          script: xcrun xcodebuild build -destination "platform=watchOS Simulator,OS=6.1,name=Apple Watch Series 4 - 44mm" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-watchOS"
 
         - stage: "Swift Package Manager"
           name: "Run Tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: swift
-osx_image: xcode11.2.1
+osx_image: xcode10.2
 
 jobs:
     include:
         - stage: "Xcode"
           name: "Run tests on iOS"
-          script: xcrun xcodebuild test -destination "platform=iOS Simulator,OS=13.2,name=iPhone X" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-iOS"
+          script: xcrun xcodebuild test -destination "platform=iOS Simulator,OS=12.2,name=iPhone X" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-iOS"
           after_success: 'bash <(curl -s https://codecov.io/bash)'
         -
           name: "Build for macOS"
           script: xcrun xcodebuild build -destination "platform=macOS" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-macOS"
         -
           name: "Build for tvOS"
-          script: xcrun xcodebuild build -destination "platform=tvOS Simulator,OS=13.2,name=Apple TV 4K" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-tvOS"
+          script: xcrun xcodebuild build -destination "platform=tvOS Simulator,OS=12.2,name=Apple TV 4K" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-tvOS"
         -
           name: "Build for watchOS"
-          script: xcrun xcodebuild build -destination "platform=watchOS Simulator,OS=6.1,name=Apple Watch Series 4 - 44mm" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-watchOS"
+          script: xcrun xcodebuild build -destination "platform=watchOS Simulator,OS=5.2,name=Apple Watch Series 4 - 44mm" -workspace "ReactiveKit.xcworkspace" -scheme "ReactiveKit-watchOS"
 
         - stage: "Swift Package Manager"
           name: "Run Tests"

--- a/Tests/ReactiveKitTests/UserTests.swift
+++ b/Tests/ReactiveKitTests/UserTests.swift
@@ -13,16 +13,16 @@ class UserTests: XCTestCase {
 
     func testDeadlockOnRetryWhen() {
 
-        let disposeBag = DisposeBag()
-
-        let queue = DispatchQueue(label: "TestSignal.Queue",
-                                  qos: .userInitiated,
-                                  attributes: DispatchQueue.Attributes.concurrent)
-
         let e = expectation(description: "Deadlock?")
         e.expectedFulfillmentCount = 500
 
+        let queue = DispatchQueue(label: "TestSignal.Queue",
+                                  qos: .userInitiated)
+
         for _ in 0..<e.expectedFulfillmentCount {
+
+            let disposeBag = DisposeBag()
+
             var signalCallCount = 0
 
             let signal = Signal<Bool, Error> { observer in
@@ -30,7 +30,7 @@ class UserTests: XCTestCase {
 
                 queue.async { [signalCallCount] in
                     switch signalCallCount {
-                    case 4:
+                    case 3:
                         observer.receive(true)
                     default:
                         observer.receive(completion: .failure(TestError.Error))
@@ -44,17 +44,19 @@ class UserTests: XCTestCase {
                 let trigger = Signal<Int, Never>(
                     sequence: 0...,
                     interval: 0.01
-                )
-                return signal.retry(when: trigger).observe(with: observer.on)
+                ).publish()
+                return CompositeDisposable([signal.retry(when: trigger).observe(with: observer),
+                                            trigger.connect()])
             }
             .observeNext {
                 if $0 {
+                    disposeBag.dispose()
                     e.fulfill()
                 }
             }
             .dispose(in: disposeBag)
         }
 
-        wait(for: [e], timeout: 5)
+        wait(for: [e], timeout: 8)
     }
 }

--- a/Tests/ReactiveKitTests/UserTests.swift
+++ b/Tests/ReactiveKitTests/UserTests.swift
@@ -11,7 +11,7 @@ import ReactiveKit
 
 class UserTests: XCTestCase {
 
-    func testDeadlock() {
+    func testDeadlockOnRetryWhen() {
 
         let disposeBag = DisposeBag()
 


### PR DESCRIPTION
In rare cases, there is a race condition when a retrying signal is disposed while the subject it is listening to is sending an event. This was causing a deadlock between the `dispose()` and the `on(_:)` functions of the observer.

This fixes it. I’ve tested tons of different scenarios. I have not been able to get this test case to pass consistently with any other method I’ve tried. With this method, my test passes consistently with any number of iterations, retries, and intervals.

The test case:
https://github.com/AnthonyMDev/ReactiveKitDeadlockDemo