### PR TITLE
Make PassthroughSubject open

### DIFF
--- a/Sources/Subjects.swift
+++ b/Sources/Subjects.swift
@@ -124,18 +124,18 @@ extension Subject: BindableProtocol {
 }
 
 /// A subject that propagates received events to the registered observes.
-public final class PassthroughSubject<Element, Error: Swift.Error>: Subject<Element, Error> {
+open class PassthroughSubject<Element, Error: Swift.Error>: Subject<Element, Error> {
 
     public override init() {
         super.init()
     }
 
-    public override func on(_ event: Signal<Element, Error>.Event) {
+    open override func on(_ event: Signal<Element, Error>.Event) {
         lock.lock(); defer { lock.unlock() }
         super.on(event)
     }
 
-    public override func observe(with observer: @escaping (Signal<Element, Error>.Event) -> Void) -> Disposable {
+    open override func observe(with observer: @escaping (Signal<Element, Error>.Event) -> Void) -> Disposable {
         lock.lock(); defer { lock.unlock() }
         return super.observe(with: observer)
     }


### PR DESCRIPTION
`Subject` cannot be subclassed in the latest version of ReactiveKit anymore because its initializer has been made `fileprivate`.

Since my project highly depends on a subclass of `Subject`, not being able to subclass it is very problematic.

This MR makes `PassthroughSubject` open, which seems to be the right class to subclass for building a custom subject from outside of ReactiveKit.