### PR TITLE
Set minimum deployment version to iOS 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveKit",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "ReactiveKit", targets: ["ReactiveKit"])


### PR DESCRIPTION
Xcode 12 doesn’t support 8 anymore and will fail to compile because Differ (via Bond) has iOS 9 as a minimum requirement.