### PR TITLE
Dynamic linking for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
-        .library(name: "ReactiveKit", targets: ["ReactiveKit"])
+        .library(name: "ReactiveKit", type: .dynamic, targets: ["ReactiveKit"])
     ],
     targets: [
         .target(name: "ReactiveKit", path: "Sources"),


### PR DESCRIPTION
Added `.dynamic` in the products definition to make sure the SPM bundle is dynamically linked.
