### PR TITLE
Add Future (Combine Style) Publisher/Signal

### DIFF
--- a/Sources/Publishers/Future.swift
+++ b/Sources/Publishers/Future.swift
@@ -1,0 +1,53 @@
+//
+//  Future.swift
+//  ReactiveKit
+//
+//  Created by Ibrahim Koteish on 05/04/2021.
+//  Copyright © 2021 DeclarativeHub. All rights reserved.
+
+import Foundation
+
+/// A signal that eventually produces single value and then finishes or fails.
+public final class Future<Element, Error: Swift.Error>: SignalProtocol {
+
+  public typealias Promise = (Result<Element, Error>) -> Void
+
+  private let subject = PassthroughSubject<Element, Error>()
+
+  private let lock = NSLock()
+  private var result: Result<Element, Error>?
+
+  public init(_ attemptToFulfill: @escaping (@escaping Promise) -> Void) {
+    attemptToFulfill(self.complete)
+  }
+
+  public func observe(with observer: @escaping Observer<Element, Error>) -> Disposable {
+    self.lock.lock(); defer { self.lock.unlock() }
+
+    if let result = self.result {
+      return Signal<Element, Error>(result: result).observe(with: observer)
+    }
+
+    let disposable = self.subject.observe(with: observer)
+    return disposable
+  }
+
+  private func complete(_ result: Result<Element, Error>) {
+
+    self.lock.lock()
+    guard self.result == nil else {
+      self.lock.unlock()
+      return
+    }
+
+    self.result = result
+    self.lock.unlock()
+
+    switch result {
+    case let .success(output):
+      self.subject.send(lastElement: output)
+    case let .failure(error):
+      self.subject.send(completion: .failure(error))
+    }
+  }
+}

--- a/Tests/ReactiveKitTests/FutureTests.swift
+++ b/Tests/ReactiveKitTests/FutureTests.swift
@@ -1,0 +1,109 @@
+//
+//  FutureTests.swift
+//  ReactiveKit
+//
+//  Created by Ibrahim Koteish on 05/04/2021.
+//  Copyright © 2021 DeclarativeHub. All rights reserved.
+
+import XCTest
+import ReactiveKit
+
+
+final class FutureTests: XCTestCase {
+
+  func testSuccessFuture() {
+
+    let exp = XCTestExpectation()
+
+    let future = Future<Int, Never> { callback in
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        callback(.success(42))
+        exp.fulfill()
+      }
+    }
+
+    let futureAcc = Subscribers.Accumulator<Int, Never>()
+    future.subscribe(futureAcc)
+
+    wait(for: [exp], timeout: 0.2)
+
+    XCTAssertEqual(futureAcc.values, [42])
+    XCTAssertTrue(futureAcc.isFinished)
+
+  }
+
+  func testSuccessFutureWithResult() {
+
+
+    let future = Future<Int, Never> { callback in
+        callback(.success(42))
+    }
+
+    let futureAcc = Subscribers.Accumulator<Int, Never>()
+    future.subscribe(futureAcc)
+
+    XCTAssertEqual(futureAcc.values, [42])
+    XCTAssertTrue(futureAcc.isFinished)
+
+    let futureAcc2 = Subscribers.Accumulator<Int, Never>()
+    future.subscribe(futureAcc2)
+
+    XCTAssertEqual(futureAcc2.values, [42])
+    XCTAssertTrue(futureAcc2.isFinished)
+
+  }
+
+  func testdoubleCallback() {
+
+    let exp = XCTestExpectation()
+
+    let future = Future<Int, Never> { callback in
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        callback(.success(42))
+        callback(.success(24))
+        exp.fulfill()
+      }
+    }
+
+    wait(for: [exp], timeout: 0.2)
+
+    let futureAcc = Subscribers.Accumulator<Int, Never>()
+    future.subscribe(futureAcc)
+
+    XCTAssertEqual(futureAcc.values, [42])
+    XCTAssertTrue(futureAcc.isFinished)
+
+    let futureAcc2 = Subscribers.Accumulator<Int, Never>()
+    future.subscribe(futureAcc2)
+
+    XCTAssertEqual(futureAcc2.values, [42])
+    XCTAssertTrue(futureAcc2.isFinished)
+
+  }
+
+  func testFailureFuture() {
+
+    enum FutureError: Error {
+      case badFuture
+    }
+
+    let exp = XCTestExpectation()
+
+    let future = Future<Int, FutureError> { callback in
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        callback(.failure(.badFuture))
+        exp.fulfill()
+      }
+    }
+
+    let futureAcc = Subscribers.Accumulator<Int, FutureError>()
+    future.subscribe(futureAcc)
+
+    wait(for: [exp], timeout: 0.2)
+
+    XCTAssertEqual(futureAcc.values, [])
+    XCTAssertEqual(futureAcc.error, .badFuture)
+    XCTAssertTrue(futureAcc.isFailure)
+
+  }
+}


### PR DESCRIPTION
Add Future publisher/Signal that eventually produces a single value and then finishes or fails.
 

```swift
Future<Int, Never> { callback in
     DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
        callback(.success(42))
     }
  }
}
```

[Combine](https://developer.apple.com/documentation/combine/future)